### PR TITLE
BACKLOG-13651: Switch from query:definition tag to jcr:sql tag 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MC0CFQCGNMgmNnACK7eXK5MWzQpf2N37kwIUZiHu83hHJFl6DqMBsfokgm4CkqE=</jahia-module-signature>
+        <jahia-module-signature>MC0CFAm6mG1u8DMFCcAfdksDISeeH/OAAhUAj5m2xXIWnz/yh+E0blpt0yB3q8k=</jahia-module-signature>
     </properties>
 
     <repositories>

--- a/src/main/resources/jnt_currentUserTasks/html/currentUserTasks.hidden.load.jsp
+++ b/src/main/resources/jnt_currentUserTasks/html/currentUserTasks.hidden.load.jsp
@@ -76,6 +76,5 @@
     </c:if>
 </c:if>
 
-<query:definition var="listQuery" statement="${sql}" scope="request"/>
-<c:set target="${moduleMap}" property="listQuery" value="${listQuery}" />
+<c:set target="${moduleMap}" property="listQuerySql" value="${sql}" />
 <c:set var="editable" value="false" scope="request"/>


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13651

## Description

BACKLOG-13651: Switch from query:definition tag to jcr:sql tag (used inside https://github.com/Jahia/default/blob/master/src/main/resources/jmix_list/html/list.hidden.header.jsp) by only defining the SQL statement. Using query definition tag break the query with LDAP users (works with Jahia users) 

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
